### PR TITLE
Fix link-preview image: use absolute og:image URL

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,9 +8,14 @@
 
   <meta property="og:title" content="aloud.">
   <meta property="og:description" content="A meditation facilitator that listens and responds to your voice.">
-  <meta property="og:image" content="assets/aloud.png">
+  <meta property="og:image" content="https://aloud.rest/assets/aloud.png">
+  <meta property="og:image:width" content="512">
+  <meta property="og:image:height" content="512">
+  <meta property="og:image:alt" content="aloud. app icon">
+  <meta property="og:url" content="https://aloud.rest/">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://aloud.rest/assets/aloud.png">
 
   <link rel="icon" type="image/png" href="assets/aloud.png">
   <link rel="apple-touch-icon" href="assets/aloud.png">


### PR DESCRIPTION
Discord, Messenger, and Facebook crawlers don't resolve relative og:image paths, so the relative "assets/aloud.png" produced no preview image. Switch to the absolute https://aloud.rest/ URL and add og:url, twitter:image, and og:image dimensions/alt for robustness across crawlers.