### PR TITLE
Fix settings overflow at large text-scale (meditation-pal-93b)

### DIFF
--- a/ts/ui/src/style.css
+++ b/ts/ui/src/style.css
@@ -213,6 +213,18 @@
     font-size: 0.8em;
 }
 
+/* meditation-pal-93b: the lifted breakpoints key off viewport width only,
+   so a bumped --text-scale widens content without moving the breakpoint and
+   these rows overflow. Let them reflow intrinsically — wraps on overflow from
+   any cause (narrow viewport or large text), independent of the px breakpoints. */
+.settings-footer-secondary {
+    flex-wrap: wrap;
+}
+.btn-begin {
+    max-width: 100%;
+    flex-wrap: wrap;
+}
+
 /* History view: the markup uses the lifted .history-container / .history-header
    / .session-item classes, so styling cascades from the @import. (The earlier
    from-scratch .history-row/.history-list rules were dead and removed.) */


### PR DESCRIPTION
Fixes `meditation-pal-93b` (still open on ts-core).

## Problem

The in-app text-scale is applied as `body { font-size: calc(18px * var(--text-scale)) }` — a CSS variable. The settings page's responsive breakpoints (lifted from the Python `style.css` via the `@import`) key off **viewport width** only. Media-query `em`/`rem` units are evaluated against the browser default (16px), not author font-size, so they can't be made to respond to `--text-scale`. Result: at bumped text sizes, the Save Settings button and the settings footer widen past the viewport before the next px breakpoint fires.

## Fix

Add TS-side overrides that let those rows reflow **intrinsically** (`flex-wrap`, plus `max-width: 100%` on the button), so they wrap on overflow from any cause — narrow viewport *or* large text — independent of the px breakpoints. Additive; no change at normal sizes.

## Notes

- Lives in `ts/ui/src/style.css` (the TS override layer), so it survives the eventual Python-CSS lift (`cfy`).
- ⚠️ **Not visually verified** — no browser in the authoring environment. Worth an eyeball at ~150%+ text-scale on the settings page before merge.
- `npm run ui:build` passes.

https://claude.ai/code/session_01NfmoHNR2GErHrqn8pqhXqW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfmoHNR2GErHrqn8pqhXqW)_