### PR TITLE
fix(stt): don't starve mobile Web Speech recognition with the mic-meter stream

### DIFF
--- a/ts/ui/src/is-desktop.ts
+++ b/ts/ui/src/is-desktop.ts
@@ -35,6 +35,21 @@ export function isTauri(): boolean {
     );
 }
 
+/**
+ * Synchronous "are we on Android" check (userAgent sniff).
+ *
+ * Used to gate behavior that depends on Android's single-owner microphone:
+ * unlike desktop Chrome, Android hands the mic to exactly one consumer, so a
+ * second `getUserMedia` capture (e.g. the cosmetic mic-level meter) starves the
+ * Web Speech system recognizer and recognition silently returns no results.
+ * See startMeter() in views/session.ts.
+ */
+export function isAndroid(): boolean {
+    return (
+        typeof navigator !== 'undefined' && /Android/i.test(navigator.userAgent || '')
+    );
+}
+
 let cached: boolean | null = null;
 let inflight: Promise<boolean> | null = null;
 

--- a/ts/ui/src/is-desktop.ts
+++ b/ts/ui/src/is-desktop.ts
@@ -36,18 +36,27 @@ export function isTauri(): boolean {
 }
 
 /**
- * Synchronous "are we on Android" check (userAgent sniff).
+ * Synchronous "is this a mobile OS that hands the microphone to a single
+ * owner" check (userAgent / platform sniff for Android + iOS/iPadOS).
  *
- * Used to gate behavior that depends on Android's single-owner microphone:
- * unlike desktop Chrome, Android hands the mic to exactly one consumer, so a
- * second `getUserMedia` capture (e.g. the cosmetic mic-level meter) starves the
- * Web Speech system recognizer and recognition silently returns no results.
- * See startMeter() in views/session.ts.
+ * Unlike desktop browsers, which let multiple captures share the mic, mobile
+ * Safari and Android Chrome give it to exactly one consumer. So a second
+ * `getUserMedia` capture (e.g. the cosmetic mic-level meter) starves the Web
+ * Speech system recognizer and recognition silently returns no results — the
+ * mic ring pulses while nothing is ever transcribed. startMeter() (views/
+ * session.ts) uses this to skip the meter on the Web Speech path there.
+ *
+ * iPadOS 13+ Safari masquerades as desktop Mac, so it's caught via touch
+ * points rather than the UA string (Macs aren't touchscreens).
  */
-export function isAndroid(): boolean {
-    return (
-        typeof navigator !== 'undefined' && /Android/i.test(navigator.userAgent || '')
-    );
+export function isSingleOwnerMicPlatform(): boolean {
+    if (typeof navigator === 'undefined') return false;
+    const ua = navigator.userAgent || '';
+    const platform = navigator.platform || '';
+    if (/Android/i.test(ua)) return true;
+    if (/iPhone|iPad|iPod/i.test(ua) || /iPhone|iPad|iPod/i.test(platform)) return true;
+    // iPadOS desktop-mode Safari reports as "MacIntel" but exposes touch.
+    return /Mac/i.test(platform) && (navigator.maxTouchPoints ?? 0) > 1;
 }
 
 let cached: boolean | null = null;

--- a/ts/ui/src/views/session.ts
+++ b/ts/ui/src/views/session.ts
@@ -73,7 +73,7 @@ import { showBuyCreditsModal } from '../buy-credits-modal.js';
 import { playCannedApology } from '../canned-apology.js';
 import { OUT_OF_CREDITS_MESSAGE, BILLING_PAUSED_FINISH } from '../billing-messages.js';
 import { startMicMeter, type MicMeter } from '../mic-meter.js';
-import { isTauri } from '../is-desktop.js';
+import { isTauri, isAndroid } from '../is-desktop.js';
 import { acquireWakeLock, releaseWakeLock } from '../wakelock.js';
 import { appUrl } from '../app-base.js';
 import {
@@ -1247,8 +1247,16 @@ export async function mountSessionView(
     // mic stream. The old desktop-only analyser stream made macOS re-arbitrate
     // its single voice-processing input between two captures, which could
     // glitch or hard-zero the engine's stream mid-utterance (lost words no VAD
-    // can recover). Web Speech hides its audio entirely, so it keeps the small
-    // dedicated meter stream (cosmetic — failures swallowed).
+    // can recover). Web Speech hides its audio entirely, so on the desktop it
+    // keeps the small dedicated meter stream (cosmetic — failures swallowed).
+    //
+    // BUT on Android the mic has a single owner: the dedicated getUserMedia
+    // meter stream starves the system speech recognizer, so onresult never
+    // fires — the ring pulses while no words are ever transcribed (the
+    // android-chrome-speech-display bug). Skip the meter there; recognition
+    // matters more than a cosmetic ring, and Web Speech gives us no stream to
+    // share. (iOS Safari doesn't expose Web Speech, so this path is Android-only
+    // on mobile.)
     let micMeter: MicMeter | null = null;
     let engineMeterOn = false;
     function startMeter(): void {
@@ -1266,6 +1274,8 @@ export async function mountSessionView(
             return;
         }
         if (micMeter || sttBackend !== 'web-speech') return;
+        // A second mic capture starves the Android system recognizer (see above).
+        if (isAndroid()) return;
         void startMicMeter(micBtn)
             .then((m) => {
                 if (torn || muted) m.stop(); // raced with teardown/mute

--- a/ts/ui/src/views/session.ts
+++ b/ts/ui/src/views/session.ts
@@ -73,7 +73,7 @@ import { showBuyCreditsModal } from '../buy-credits-modal.js';
 import { playCannedApology } from '../canned-apology.js';
 import { OUT_OF_CREDITS_MESSAGE, BILLING_PAUSED_FINISH } from '../billing-messages.js';
 import { startMicMeter, type MicMeter } from '../mic-meter.js';
-import { isTauri, isAndroid } from '../is-desktop.js';
+import { isTauri, isSingleOwnerMicPlatform } from '../is-desktop.js';
 import { acquireWakeLock, releaseWakeLock } from '../wakelock.js';
 import { appUrl } from '../app-base.js';
 import {
@@ -1250,13 +1250,15 @@ export async function mountSessionView(
     // can recover). Web Speech hides its audio entirely, so on the desktop it
     // keeps the small dedicated meter stream (cosmetic — failures swallowed).
     //
-    // BUT on Android the mic has a single owner: the dedicated getUserMedia
+    // BUT on mobile the mic has a single owner: the dedicated getUserMedia
     // meter stream starves the system speech recognizer, so onresult never
     // fires — the ring pulses while no words are ever transcribed (the
-    // android-chrome-speech-display bug). Skip the meter there; recognition
-    // matters more than a cosmetic ring, and Web Speech gives us no stream to
-    // share. (iOS Safari doesn't expose Web Speech, so this path is Android-only
-    // on mobile.)
+    // android-chrome-speech-display bug). Skip the meter on those platforms;
+    // recognition matters more than a cosmetic ring, and Web Speech gives us no
+    // stream to share. Android Chrome is the confirmed case; iOS/iPadOS Safari
+    // is gated defensively too — if a future iOS exposes Web Speech here, it has
+    // the same single-owner mic and would hit the identical bug (and if it
+    // doesn't reach this path, the sttBackend check above already returns).
     let micMeter: MicMeter | null = null;
     let engineMeterOn = false;
     function startMeter(): void {
@@ -1274,8 +1276,9 @@ export async function mountSessionView(
             return;
         }
         if (micMeter || sttBackend !== 'web-speech') return;
-        // A second mic capture starves the Android system recognizer (see above).
-        if (isAndroid()) return;
+        // A second mic capture starves the system recognizer on single-owner
+        // mic platforms (Android, iOS/iPadOS) — see above.
+        if (isSingleOwnerMicPlatform()) return;
         void startMicMeter(micBtn)
             .then((m) => {
                 if (torn || muted) m.stop(); // raced with teardown/mute


### PR DESCRIPTION
## Summary

Fixes a bug where, on **Android Chrome** (reported in a live demo), the user's speech was never transcribed and the facilitator never responded — even though the mic-level ring kept pulsing as she spoke.

### Root cause

On the Web Speech STT path the UI runs **two independent microphone consumers** at once:

1. **The mic-level ring** — `mic-meter.ts` opens its *own* `getUserMedia({ audio: true })` stream and runs it through an `AnalyserNode` to pulse the `--mic-level` box-shadow ring.
2. **The recognizer** — `web-speech-stt.ts` uses the Web Speech API, which on Android Chrome is backed by the **Android system speech recognizer** (a separate process from Chrome's audio capture).

On the desktop the two coexist, so it demos fine there. But **mobile OSes hand the microphone to a single owner**: once the page holds the mic via `getUserMedia` (for the ring), the system recognizer can't acquire it, so `onresult` never fires — no `partial`/`final` events reach the listen loop. The ring pulses (its `getUserMedia` stream is the one that works) while nothing is ever transcribed.

This is the same single-input arbitration that previously glitched the desktop server-Whisper engine (see the comment at `session.ts` `startMeter`), which was fixed there by dropping the second stream and feeding the meter from the engine's own RMS. The Web Speech path was left with its second stream — and that's what breaks on mobile.

### Fix

Web Speech exposes no audio stream to share, so on single-owner-mic platforms we skip the cosmetic meter entirely and let the recognizer own the mic. The ring stays static; recognition works. Desktop Chrome/Edge are unchanged and keep their ring.

The gate is `isSingleOwnerMicPlatform()` (Android + iOS/iPadOS, including iPadOS desktop-mode Safari detected via touch points), not just Android — see the platform analysis below.

### Platform impact (incl. iOS, which I couldn't test directly)

| Platform | STT backend | Second mic stream? | Risk |
|---|---|---|---|
| Desktop Chrome/Edge | web-speech | yes (meter) | None — concurrent capture OK ✅ |
| **Android Chrome** | web-speech | yes (meter) | **The bug** — fixed |
| **iOS Safari (web app)** | web-speech *if exposed* | yes (meter) | **Same bug if it reaches this path** — fixed defensively |
| iOS/Android Capacitor (native) | capacitor | no (meter gated to web-speech) | None |
| iOS Safari (Web Speech not exposed) | aloud cloud → server-whisper | no — meter from engine RMS | None |
| Desktop (Tauri) | server-whisper | no — engine RMS | None (already fixed) |

iOS Safari has shipped `webkitSpeechRecognition` since iOS 14.5, so `isWebSpeechSupported()` can return true and the picker may select web-speech as the iOS default — and iOS has the *same* single-owner mic semantics as Android, so it would hit the identical failure. The gate is defensive: if iOS doesn't reach the web-speech path, the existing `sttBackend !== 'web-speech'` check returns first, so the only cost is ever a cosmetic ring on the mobile web-speech path.

### Follow-up worth noting (not in this PR)

The adapter header in `web-speech-stt.ts` claims Apple doesn't expose `SpeechRecognition` on iOS; if iOS Safari actually reaches the web-speech backend, that comment is stale and iOS web-speech reliability deserves its own pass. Flagging for a future look rather than changing behavior here.

## Testing

- `npm run typecheck` — clean
- `npm test` — all 370 tests pass

Confirmation on a real Android (and iOS) device is the remaining validation I can't do from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011abYkzxaP1KHTcpMggVAx9)_