### PR TITLE
fix(stt/voices): in-session cloud STT switch, clearer blocked-mic help, browser voice-preview failures

### DIFF
--- a/ts/src-tauri/src/providers.rs
+++ b/ts/src-tauri/src/providers.rs
@@ -81,8 +81,10 @@ pub fn providers() -> Value {
             "hint": if has_claude {
                 ""
             } else {
-                "Claude Code CLI is not installed. Install Claude Code, then \
-                 run `claude` once to log in with your Pro/Max subscription."
+                "The Claude Code command-line tool isn't installed. Install the \
+                 CLI with `npm install -g @anthropic-ai/claude-code` — not the \
+                 Claude desktop app, which can't sign in here — then run \
+                 `claude` once to log in with your Pro/Max subscription."
             },
         },
         "anthropic": api_key_provider("ANTHROPIC_API_KEY"),

--- a/ts/tests/browser-tts.test.ts
+++ b/ts/tests/browser-tts.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { BrowserTtsEngine } from '../ui/src/adapters/browser-tts.js';
+
+/** Minimal SpeechSynthesisUtterance stand-in that captures the event handlers
+ *  BrowserTtsEngine wires, so a test can fire onend / onerror by hand. */
+class FakeUtterance {
+    text: string;
+    rate = 1;
+    pitch = 1;
+    voice: unknown = null;
+    lang = '';
+    onstart: (() => void) | null = null;
+    onend: (() => void) | null = null;
+    onerror: ((event: { error: string }) => void) | null = null;
+    constructor(text: string) {
+        this.text = text;
+    }
+}
+
+function stubSpeechSynthesis(): { spoken: FakeUtterance[] } {
+    const spoken: FakeUtterance[] = [];
+    vi.stubGlobal('SpeechSynthesisUtterance', FakeUtterance);
+    vi.stubGlobal('speechSynthesis', {
+        speak: (u: FakeUtterance) => spoken.push(u),
+        cancel: () => {},
+        resume: () => {},
+        getVoices: () => [],
+    });
+    return { spoken };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('BrowserTtsEngine.speak error handling', () => {
+    it('rejects on a genuine synthesis error (the silent-preview bug)', async () => {
+        const { spoken } = stubSpeechSynthesis();
+        const engine = new BrowserTtsEngine();
+        const p = engine.speak('hello');
+        spoken.at(-1)!.onerror!({ error: 'synthesis-failed' });
+        await expect(p).rejects.toThrow(/synthesis-failed/);
+    });
+
+    it('resolves quietly on interrupted/canceled (our own cancel churn)', async () => {
+        const { spoken } = stubSpeechSynthesis();
+        const engine = new BrowserTtsEngine();
+        for (const code of ['interrupted', 'canceled']) {
+            const p = engine.speak('hello');
+            spoken.at(-1)!.onerror!({ error: code });
+            await expect(p).resolves.toBeUndefined();
+        }
+    });
+
+    it('resolves on normal end', async () => {
+        const { spoken } = stubSpeechSynthesis();
+        const engine = new BrowserTtsEngine();
+        const p = engine.speak('hello');
+        spoken.at(-1)!.onend!();
+        await expect(p).resolves.toBeUndefined();
+    });
+});

--- a/ts/tests/voice-picker.test.ts
+++ b/ts/tests/voice-picker.test.ts
@@ -4,6 +4,7 @@ import {
     downloadPercent,
     downloadVoiceModel,
     prefixedVoiceId,
+    previewErrorMessage,
 } from '../ui/src/voice-picker.js';
 
 afterEach(() => vi.unstubAllGlobals());
@@ -217,5 +218,25 @@ describe('Best tier is reserved for hosted + Chrome cloud (not macOS/Piper)', ()
         const goog = scored.find((v) => v.name === 'Google US English')!;
         expect(goog.recommended).toBe(true); // Chrome cloud → Best
         expect(goog.displayEngine).toBeUndefined();
+    });
+});
+
+describe('previewErrorMessage', () => {
+    it('gives a browser-voice-specific hint for a speechSynthesis failure', () => {
+        // The Microsoft "Online (Natural)" case: BrowserTtsEngine rejects with
+        // "speechSynthesis synthesis-failed" when a remote voice won't render.
+        const msg = previewErrorMessage(new Error('speechSynthesis synthesis-failed'));
+        expect(msg).toMatch(/Online/i);
+        expect(msg).toMatch(/another voice|aloud cloud/i);
+    });
+
+    it('maps hosted credit/auth failures to their own lines', () => {
+        expect(previewErrorMessage(new Error('TTS endpoint 402'))).toMatch(/credit/i);
+        expect(previewErrorMessage(new Error('TTS endpoint 401'))).toMatch(/sign in/i);
+    });
+
+    it('falls back to a generic line for an unknown failure', () => {
+        const msg = previewErrorMessage(new Error('something odd'));
+        expect(msg).toMatch(/Couldn't play/i);
     });
 });

--- a/ts/ui/src/adapters/browser-tts.ts
+++ b/ts/ui/src/adapters/browser-tts.ts
@@ -22,6 +22,7 @@ export interface BrowserTtsEngineOptions {
 export class BrowserTtsEngine implements TtsEngine {
     private currentUtterance: SpeechSynthesisUtterance | null = null;
     private currentResolve: (() => void) | null = null;
+    private currentReject: ((err: Error) => void) | null = null;
     private readonly defaultVoice: string | undefined;
 
     constructor(options: BrowserTtsEngineOptions = {}) {
@@ -33,7 +34,7 @@ export class BrowserTtsEngine implements TtsEngine {
 
     speak(text: string, options?: TtsOptions): Promise<void> {
         this.cancelSync();
-        return new Promise<void>((resolve) => {
+        return new Promise<void>((resolve, reject) => {
             const utterance = new SpeechSynthesisUtterance(text);
             if (options?.rate !== undefined) {
                 // speechSynthesis rate is 0.1–10, 1.0 neutral. The TtsOptions
@@ -61,9 +62,17 @@ export class BrowserTtsEngine implements TtsEngine {
             // starts producing audio (synthesis can lag speak() by a beat).
             if (options?.onStart) utterance.onstart = options.onStart;
             utterance.onend = () => this.finish(utterance);
-            utterance.onerror = () => this.finish(utterance);
+            // Surface a genuine synthesis failure instead of resolving as if the
+            // voice spoke. Chrome/Edge fire `onerror` with synthesis-failed /
+            // synthesis-unavailable / network for remote "Online (Natural)"
+            // voices that can't render — previously this resolved like `onend`,
+            // so previewing such a voice was silent with no explanation. Our own
+            // cancel()/new-speak fire error 'interrupted'/'canceled'; those are
+            // normal teardown, not failures, so finish() resolves quietly for them.
+            utterance.onerror = (event) => this.finish(utterance, event.error);
             this.currentUtterance = utterance;
             this.currentResolve = resolve;
+            this.currentReject = reject;
             speechSynthesis.speak(utterance);
             // Android Chrome leaves the speech queue *paused* after a preceding
             // cancel() (the voice picker calls cancel() then speak() to preview),
@@ -87,11 +96,22 @@ export class BrowserTtsEngine implements TtsEngine {
         }
     }
 
-    private finish(utterance: SpeechSynthesisUtterance): void {
+    private finish(utterance: SpeechSynthesisUtterance, error?: string): void {
         if (this.currentUtterance !== utterance) return;
         this.currentUtterance = null;
         const resolve = this.currentResolve;
+        const reject = this.currentReject;
         this.currentResolve = null;
+        this.currentReject = null;
+        // 'interrupted' / 'canceled' are our own cancel()/new-speak churn, not a
+        // real failure — resolve quietly. Anything else (synthesis-failed,
+        // synthesis-unavailable, network, voice-unavailable, …) means no audio
+        // played: reject so the voice preview can say why.
+        if (error && error !== 'interrupted' && error !== 'canceled') {
+            if (reject) reject(new Error(`speechSynthesis ${error}`));
+            else if (resolve) resolve();
+            return;
+        }
         if (resolve) resolve();
     }
 

--- a/ts/ui/src/app-base.css
+++ b/ts/ui/src/app-base.css
@@ -1382,6 +1382,28 @@ body:has(.session-container) {
     color: var(--text-secondary);
     font-size: 0.85rem;
     line-height: 1.4;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem 0.75rem;
+}
+
+/* One-click switch to aloud cloud speech, shown in the trouble banner when the
+   browser recognizer is blocked. Compact and calm — a way out, not an alarm. */
+.stt-trouble-btn {
+    flex: none;
+    padding: 0.3rem 0.75rem;
+    border-radius: var(--radius);
+    border: 1px solid var(--warm);
+    background: color-mix(in srgb, var(--warm) 22%, transparent);
+    color: var(--text-primary);
+    font: inherit;
+    font-size: 0.82rem;
+    cursor: pointer;
+}
+
+.stt-trouble-btn:hover {
+    background: color-mix(in srgb, var(--warm) 32%, transparent);
 }
 
 .voice-status {

--- a/ts/ui/src/tour/settings-tour.ts
+++ b/ts/ui/src/tour/settings-tour.ts
@@ -264,7 +264,7 @@ function showLLMStep(): void {
         // Claude subscription
         html += '<button class="tour-choice" data-action="provider" data-value="claude_proxy">';
         html += '<strong>I have a Claude subscription</strong>';
-        html += '<small>Uses your Pro or Max plan via the locally-installed <code>claude</code> CLI (Claude Code).</small>';
+        html += '<small>Uses your Pro or Max plan via the locally-installed <code>claude</code> command-line tool — install Claude Code with <code>npm install -g @anthropic-ai/claude-code</code> (the CLI, not the Claude desktop app).</small>';
         html += '</button>';
 
         // API key

--- a/ts/ui/src/views/session.ts
+++ b/ts/ui/src/views/session.ts
@@ -49,6 +49,7 @@ import {
     sttBackendForChoice,
     resolveSttChoice,
     invalidateSttBackendCache,
+    sttEngineOptions,
     type SttBackend,
 } from '../adapters/stt-picker.js';
 import { isWebMode } from '../app-mode.js';
@@ -56,7 +57,7 @@ import { createTtsForVoice, createCloudAloudTts } from '../adapters/tts-picker.j
 import { WhisperPcmSttEngine } from '../adapters/whisper-pcm-stt.js';
 import { startCloudSession, clearCloudSession } from '../cloud-session.js';
 import { type SessionSetup, dirStepToBackend } from '../settings.js';
-import { loadAppSettings } from '../app-settings.js';
+import { loadAppSettings, saveAppSettings, type SttEngineChoice } from '../app-settings.js';
 import { sessionStore } from '../state.js';
 import { markSessionStarted } from '../tour/index-guide.js';
 import { showEndConfirm as wireEndConfirm } from './end-confirm.js';
@@ -297,23 +298,26 @@ export async function mountSessionView(
     // Whisper locally, browser speech, or the aloud cloud (credits). No
     // hidden automatic; resolveSttChoice falls back to the mode's flow default
     // when nothing's been chosen.
-    const sttChoice = resolveSttChoice(appSettings.sttEngine, isWebMode());
-    const stt: SttEngine | null = await createSttForChoice(sttChoice, vadOpts);
-    const sttBackend: SttBackend = sttBackendForChoice(sttChoice);
+    // `let` (not const) on the STT config below: a blocked browser recognizer
+    // can be swapped to aloud cloud mid-session via switchSttEngine (the STT
+    // trouble banner's button), which re-derives all of these.
+    let sttChoice = resolveSttChoice(appSettings.sttEngine, isWebMode());
+    let stt: SttEngine | null = await createSttForChoice(sttChoice, vadOpts);
+    let sttBackend: SttBackend = sttBackendForChoice(sttChoice);
 
     // server-Whisper detects barge-in on its own continuous capture stream, so
     // we DON'T wrap TTS with the separate-stream detector there (a second mic
     // stream doesn't get the OS echo-cancellation and trips on the
     // facilitator's own voice — the self-barge-in bug). Other STT backends
     // (web-speech, capacitor) have no such stream, so they keep the wrapper.
-    const engineDrivenBargeIn = sttBackend === 'server-whisper';
+    let engineDrivenBargeIn = sttBackend === 'server-whisper';
     // Continuous capture (meditation-pal-57gl): on the engine-driven (server-
     // Whisper) path the mic stays live through the LLM+TTS window instead of
     // pausing while `busy`, so the user is never "deaf" mid-response. Its VAD
     // rejects TTS echo (the measured echo gate + energy floor vs ~0.005 echo),
     // so this is safe there; web-speech / capacitor can't reject echo in their
     // recognizers, so they keep pause-while-busy + the barge-in wrapper.
-    const continuousCapture = engineDrivenBargeIn;
+    let continuousCapture = engineDrivenBargeIn;
     // Turn supersession + barge-in plumbing (see respondTo / the barge-in
     // handler). turnGen bumps each turn so a stale (superseded) turn bails;
     // activeFullAbort stops a superseded turn generating; activeTtsAbort hushes
@@ -323,7 +327,7 @@ export async function mountSessionView(
     let activeTtsAbort: AbortController | null = null;
     // The continuous-capture engine, when that's the live backend — used for
     // barge-in wiring and per-device echo calibration (setTtsActive below).
-    const whisperEngine =
+    let whisperEngine: WhisperPcmSttEngine | null =
         continuousCapture && stt instanceof WhisperPcmSttEngine ? stt : null;
     async function buildTts(voiceId: string | null) {
         // Server-side synthesis is billable compute — fold chars into usage.
@@ -391,10 +395,13 @@ export async function mountSessionView(
     }
     function ttsPlaybackEnded(): void {
         lastTtsEndedAt = Date.now();
-        if (!whisperEngine) return;
+        // Capture the current engine: whisperEngine is now reassignable (an
+        // in-session STT switch), so pin the one this playback belongs to.
+        const engine = whisperEngine;
+        if (!engine) return;
         ttsActiveOffTimer = setTimeout(() => {
             ttsActiveOffTimer = null;
-            if (ttsSpeakingDepth === 0) whisperEngine.setTtsActive(false);
+            if (ttsSpeakingDepth === 0) engine.setTtsActive(false);
         }, TTS_ACTIVE_HANGOVER_MS);
     }
     /** Echo can only arrive while audio plays or shortly after (capture +
@@ -436,8 +443,11 @@ export async function mountSessionView(
     } satisfies TtsEngine;
     // For the server-Whisper STT path, barge-in is detected on its continuous
     // (echo-cancelled) capture stream — see setBargeInHandler below. Wiring it
-    // up here, after the tts wrapper exists; the engine cancels the live TTS.
-    if (whisperEngine) {
+    // up after the tts wrapper exists; the engine cancels the live TTS. Extracted
+    // so a mid-session switch to the cloud (server-Whisper) engine can re-wire
+    // the new engine's stream (switchSttEngine calls this again).
+    function wireWhisperBargeIn(): void {
+        if (!whisperEngine) return;
         whisperEngine.setBargeInHandler(() => {
             // Only meaningful while the facilitator is actively responding: hush
             // it so the user isn't talked over. The utterance keeps being
@@ -453,6 +463,7 @@ export async function mountSessionView(
             onBargeIn();
         });
     }
+    wireWhisperBargeIn();
 
     // The session view also injects an orb into the global nav's
     // .nav-center slot and overrides the nav links to End / History.
@@ -534,16 +545,97 @@ export async function mountSessionView(
     /** Show the banner once failures pass the threshold; called on each STT error. */
     function noteSttFailure(): void {
         sttFailureStreak++;
-        if (sttFailureStreak >= 2 && sttTroubleEl) {
-            sttTroubleEl.textContent =
-                "Trouble with speech to text. We're not catching your voice right now - check your connection, or change speech recognition in Settings.";
-            sttTroubleEl.classList.remove('hidden');
+        if (sttFailureStreak >= 2 && sttTroubleEl) renderSttTrouble();
+    }
+    /**
+     * Fill the trouble banner. When aloud cloud is an available STT option here
+     * and we're not already on it, offer a one-click switch — so a user whose
+     * browser blocks its speech recognizer (common on Edge/Windows) can get a
+     * working mic without leaving the session or hunting through Settings.
+     */
+    function renderSttTrouble(): void {
+        if (!sttTroubleEl) return;
+        const canSwitchToCloud =
+            sttChoice !== 'aloud' &&
+            sttEngineOptions(isWebMode()).some((o) => o.value === 'aloud');
+        sttTroubleEl.replaceChildren();
+        const msg = document.createElement('span');
+        msg.textContent = canSwitchToCloud
+            ? "Trouble hearing you — your browser may be blocking its speech recognition."
+            : "Trouble with speech to text. We're not catching your voice right now - check your connection, or change speech recognition in Settings.";
+        sttTroubleEl.appendChild(msg);
+        if (canSwitchToCloud) {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'stt-trouble-btn';
+            btn.textContent = 'Use aloud cloud speech';
+            btn.addEventListener('click', () => void switchSttEngine('aloud'));
+            sttTroubleEl.appendChild(btn);
         }
+        sttTroubleEl.classList.remove('hidden');
     }
     /** Clear the streak + banner; called whenever a transcription succeeds. */
     function clearSttTrouble(): void {
         sttFailureStreak = 0;
         sttTroubleEl?.classList.add('hidden');
+    }
+
+    // Guards a switch in progress so a double-click (or a fresh STT error firing
+    // renderSttTrouble again) can't build two engines at once.
+    let switchingStt = false;
+    /**
+     * Swap the live STT engine mid-session — the STT trouble banner's "Use aloud
+     * cloud speech" button. Re-derives every backend-shaped bit the listen loop,
+     * meter, and barge-in read (all `let` above), rebuilds TTS so its barge-in
+     * wrapping matches the new backend, and persists the choice so the next
+     * session keeps it. Stopping the old recognizer ends the loop's current
+     * iteration; it then re-enters on the new `stt`.
+     */
+    async function switchSttEngine(choice: SttEngineChoice): Promise<void> {
+        if (switchingStt || torn || choice === sttChoice) return;
+        switchingStt = true;
+        try {
+            setStatus('Switching to aloud cloud speech…');
+            const next = await createSttForChoice(choice, vadOpts);
+            if (!next) {
+                showErrorToast(
+                    "Couldn't start aloud cloud speech — check your connection and that you're signed in."
+                );
+                setStatus(muted ? 'Muted' : 'Listening…');
+                return;
+            }
+            const prev = stt;
+            stt = next;
+            sttChoice = choice;
+            sttBackend = sttBackendForChoice(choice);
+            engineDrivenBargeIn = sttBackend === 'server-whisper';
+            continuousCapture = engineDrivenBargeIn;
+            whisperEngine =
+                continuousCapture && next instanceof WhisperPcmSttEngine ? next : null;
+            wireWhisperBargeIn();
+            await rebuildTts(setup.voice);
+            // Persist so the next session opens on the engine that worked here.
+            try {
+                const s = await loadAppSettings();
+                await saveAppSettings({ ...s, sttEngine: choice });
+            } catch {
+                /* best-effort; the live switch still stands for this session */
+            }
+            stopMeter();
+            clearSttTrouble();
+            // Ends the loop's in-flight `for await` on the old engine; it re-enters
+            // on the new `stt`. Restart it if it had already fallen out.
+            void prev?.stop();
+            if (!muted) {
+                setStatus('Listening…');
+                startMeter();
+                if (!listenLoopRunning) void listenLoop();
+            } else {
+                setStatus('Muted');
+            }
+        } finally {
+            switchingStt = false;
+        }
     }
 
     // Staged-mode phase hint — a quiet word in the input row ("sensing",
@@ -1958,7 +2050,7 @@ export function describeCloudError(msg: string): string | null {
     return null;
 }
 
-function describeSttError(err: unknown): string {
+export function describeSttError(err: unknown): string {
     const msg = err instanceof Error ? err.message : String(err);
     // Hosted (aloud) conditions — credits / auth — get a clear, actionable line
     // instead of a raw "Whisper endpoint 402: {json}".
@@ -1971,6 +2063,19 @@ function describeSttError(err: unknown): string {
     if (/Whisper endpoint 503/.test(msg)) {
         return 'Whisper model still loading. Try again in a moment.';
     }
+    // Web Speech reports a blocked *service* (as opposed to a denied mic) with
+    // `service-not-allowed`. On Windows/Edge that's usually the OS "online
+    // speech recognition" privacy toggle being off, or an Edge/enterprise
+    // policy — the browser recognizer can't work until that's changed, so point
+    // at the in-session switch to aloud cloud (the banner button below).
+    if (msg === 'service-not-allowed') {
+        return "This browser is blocking its speech recognition (on Windows, turn on Settings → Privacy → Speech). Or switch to aloud cloud speech — it doesn't need it.";
+    }
+    // Web Speech's own denied-permission code is the hyphenated `not-allowed`
+    // (distinct from getUserMedia's `NotAllowedError`, matched below).
+    if (msg === 'not-allowed') {
+        return 'Microphone access is blocked. Allow the mic for this site (the padlock in the address bar), or switch to aloud cloud speech.';
+    }
     if (/permission/i.test(msg) || /denied/i.test(msg) || /NotAllowed/.test(msg)) {
         return 'Mic permission denied. Allow microphone access and try again.';
     }
@@ -1978,7 +2083,7 @@ function describeSttError(err: unknown): string {
     // Most often that's a Chromium build (Brave, others) where Google blocks the
     // speech endpoint, so it can never succeed - point at the paths that work.
     if (msg === 'network') {
-        return 'Browser speech recognition is blocked in this browser. Switch speech recognition to aloud cloud in Settings, or use Chrome.';
+        return 'Browser speech recognition is blocked in this browser. Switch to aloud cloud speech, or use Chrome.';
     }
     return `Mic error: ${msg}`;
 }

--- a/ts/ui/src/views/settings.ts
+++ b/ts/ui/src/views/settings.ts
@@ -1383,7 +1383,7 @@ function renderProviderSection(s: AppSettings): string {
         <h2>LLM Provider <button type="button" class="info-btn" id="llm-info-btn" aria-label="LLM provider info">?</button></h2>
         <div class="info-panel hidden" id="llm-info-panel">
             <p><strong>What is an LLM?</strong> - A large language model is the AI that listens to what you say and generates thoughtful responses to guide your meditation.</p>
-            <p><strong>Anthropic (Subscription)</strong> - Uses your existing Claude Pro/Max subscription via the locally-installed <code>claude</code> CLI. Desktop only.</p>
+            <p><strong>Anthropic (Subscription)</strong> - Uses your existing Claude Pro/Max subscription via the locally-installed <code>claude</code> command-line tool (install with <code>npm install -g @anthropic-ai/claude-code</code> — the CLI, not the Claude desktop app). Desktop only.</p>
             <p><strong>Ollama (Local)</strong> - Free and private. Runs the AI entirely on your computer.</p>
             <p><strong>API Key providers</strong> - Pay-per-use cloud AI. Sign up with the provider, paste the key here.</p>
         </div>

--- a/ts/ui/src/voice-picker.ts
+++ b/ts/ui/src/voice-picker.ts
@@ -532,6 +532,12 @@ export function previewErrorMessage(err: unknown): string {
         return 'aloud cloud voices need credits to preview. Add credits, or pick a free voice.';
     }
     if (/\b403\b/.test(msg)) return 'Verify your email to use aloud cloud voices.';
+    // A browser (speechSynthesis) voice that couldn't render — most often one of
+    // the Microsoft "Online (Natural)" voices, which need a live connection and
+    // aren't always available. Steer the user to a voice that will play.
+    if (/^speechSynthesis /.test(msg)) {
+        return "That browser voice wouldn't play — the “Online” / “Natural” voices need a connection and aren't always available. Try another voice, or aloud cloud.";
+    }
     return "Couldn't play that voice preview. Check your connection and try again.";
 }
 


### PR DESCRIPTION
Three demo fixes for the web app on Windows/Edge:

- STT blocked: Web Speech's `service-not-allowed` / `not-allowed` codes
  (what Edge/Windows raise when the OS speech privacy toggle is off or the
  mic is denied) fell through to a raw "Mic error: not-allowed". Map them to
  actionable guidance, and add a one-click "Use aloud cloud speech" button to
  the STT trouble banner that hot-swaps the live engine mid-session (re-derives
  the backend config, re-wires barge-in, rebuilds TTS, persists the choice) so
  a user with a blocked recognizer isn't stuck or sent hunting through Settings.

- Voice preview silent failure: BrowserTtsEngine.speak() resolved onerror
  identically to onend, so previewing a Microsoft "Online (Natural)" voice that
  can't render (network/synthesis-failed) was silent with no explanation. Reject
  on genuine synthesis errors (resolve quietly on our own interrupted/canceled),
  and give those a browser-voice-specific preview message.

- Claude Code install prompt: the desktop hint said "Install Claude Code",
  which users could satisfy with the Claude desktop app (can't sign in here).
  Clarify it's the command-line tool via `npm install -g @anthropic-ai/claude-code`
  in the provider hint, the settings info panel, and the onboarding tour.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FJcdCXvYZtcS1TUWSd98fL